### PR TITLE
Use Monte-Carlo Cross-Validation to generate validation samples

### DIFF
--- a/src/classification_performance_evaluation_and_comparison.py
+++ b/src/classification_performance_evaluation_and_comparison.py
@@ -1,19 +1,17 @@
 """Method to compare the performance of individual and sector approach for a pair of forex ticker and commodities
-ticker(s), and a choice of Classification model. The method uses bootstrapping to estimate the accuracy of predicting
-(discrete) hourly returns for both approaches. Then, for both the 'individual' and the 'sector' approach, using the
-results from these samples, hypothesis testing is conducted to determine if the results come from Gaussian (normal)
-distribution, and to determine if the difference in mean accuracy is statistically significant compared to random
-guessing and compared to the other approach. We assume the accuracy of random guessing to come from a Gaussian
+ticker(s), and a choice of Classification model. The method uses Monte-Carlo Cross-Validation to estimate the accuracy
+of predicting (discrete) hourly returns for both approaches. Then, for both the 'individual' and the 'sector' approach,
+using the results from these samples, hypothesis testing is conducted to determine if the results come from Gaussian
+(normal) distribution, and to determine if the difference in mean accuracy is statistically significant compared to
+random guessing and compared to the other approach. We assume the accuracy of random guessing to come from a Gaussian
 distribution with mean 0.5, because our labeled data is balanced with 50% of 'True' labels and 50% of 'False' labels."""
 
 from functools import reduce
 from operator import add
 from typing import List
 
-from sklearn.model_selection import train_test_split
-
 from src.tools.hypothesis_testing import lilliefors_test, one_sample_t_test, two_sample_t_test
-from src.tools.labeled_data_builder.bootstrap import generate_sample
+from src.tools.labeled_data_builder.monte_carlo_cross_validation import generate_train_test_sample
 from src.tools.labeled_data_builder.time_series_forecasting import create_labeled_data
 from src.tools.statistical_evaluation import ClassificationEvaluation
 from src.tools.yfinance_data_provider import YfinanceDataProvider
@@ -21,22 +19,22 @@ from src.tools.yfinance_data_provider import YfinanceDataProvider
 
 def evaluate_and_compare(forex_ticker: str, comdty_tickers: List[str], model, nb_samples: int = 100) -> None:
     """Compare the performance of individual and sector approach for a pair of forex ticker and commodities
-    ticker(s), and a choice of Classification model. The method uses bootstrapping to estimate the accuracy of
-    predicting (discrete) hourly returns for both approaches. Then, for both the 'individual' and the 'sector' approach,
-    using the results from these samples, hypothesis testing is conducted. First, the Lilliefors test is conducted to
-    determine if the results come from a Gaussian (normal) distribution, at 95% confidence. Then, one-sample T-test is
-    conducted to determine if the results are statistically significant compared to random guessing, at 95% confidence,
-    assuming that the accuracy of random guessing comes from a Gaussian distribution with mean 0.5, because our labeled
-    data is balanced with 50% of 'True' labels and 50% of 'False' labels. Finally, two-sample T-test is conducted to
-    determine if the difference in accuracy between the 'individual' and 'sector' approaches is statistically
-    significant, at 95% confidence.
+    ticker(s), and a choice of Classification model. The method uses Monte-Carlo Cross-Validation to estimate the
+    accuracy of predicting (discrete) hourly returns for both approaches. Then, for both the 'individual' and the
+    'sector' approach, using the results from these samples, hypothesis testing is conducted. First, the Lilliefors
+    test is conducted to determine if the results come from a Gaussian (normal) distribution, at 95% confidence. Then,
+    one-sample T-test is conducted to determine if the results are statistically significant compared to random
+    guessing, at 95% confidence, assuming that the accuracy of random guessing comes from a Gaussian distribution with
+    mean 0.5, because our labeled data is balanced with 50% of 'True' labels and 50% of 'False' labels. Finally,
+    two-sample T-test is conducted to determine if the difference in accuracy between the 'individual' and 'sector'
+    approaches is statistically significant, at 95% confidence.
 
     Args:
         forex_ticker (str): The ticker for the foreign exchange asset we want to predict for.
         comdty_tickers (List[str]): The ticker(s) for the commodities asset(s) we want to use as features to predict the
             foreign exchange asset.
         model: Instance of a scikit-learn Classification model, supporting methods fit() and predict().
-        nb_samples (int): The number of samples to generate from the labeled data, using bootstrapping.
+        nb_samples (int): The number of samples to generate from the labeled data, using Monte-Carlo Cross-Validation.
 
     """
 
@@ -51,8 +49,7 @@ def evaluate_and_compare(forex_ticker: str, comdty_tickers: List[str], model, nb
 
     accuracies = {"individual": [], "sector": []}
     for i in range(nb_samples):
-        sample = generate_sample(data=labeled_data)
-        train_data, test_data = train_test_split(sample, train_size=0.8)
+        train_data, test_data = generate_train_test_sample(data=labeled_data, train_percentage=0.8)
         for approach in ["individual", "sector"]:
             model.fit(list(train_data[f"features_{approach}"].values), list(train_data["label"].values))
             predictions = model.predict(list(test_data[f"features_{approach}"].values))

--- a/src/tools/labeled_data_builder/monte_carlo_cross_validation.py
+++ b/src/tools/labeled_data_builder/monte_carlo_cross_validation.py
@@ -1,0 +1,32 @@
+"""Method(s) to generate simulated samples from a dataset, using Monte-Carlo Cross-Validation."""
+
+from random import sample
+from typing import Tuple
+
+import pandas as pd
+
+
+def generate_train_test_sample(data: pd.DataFrame, train_percentage: float = 0.8) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Generate a new simulated sample from the given data, using Monte-Carlo Cross-Validation. The generated sample
+    differentiates a new random partition between train and test data, the entire original dataset is used in the
+    generated sample (the sample is of the same size as the original DataFrame).
+
+    Args:
+        data (pd.DataFrame): The original data to sample from.
+        train_percentage (float): Proportion of labeled data going into the train dataset, between 0 and 1 inclusive.
+
+    Returns:
+        train_sample (pd.DataFrame): The generated train subset sample.
+        test_sample (pd.DataFrame): The generated test subset sample.
+
+    """
+
+    if not 0 <= train_percentage <= 1:
+        raise ValueError("Parameter 'train_percentage' must be a number between 0 and 1 inclusive.")
+
+    test_size = int((1 - train_percentage) * len(data))
+    test_index = sample(list(range(len(data))), test_size)
+    train_data = data.iloc[[i for i in range(len(data)) if i not in test_index]]
+    test_data = data.iloc[test_index]
+
+    return train_data, test_data

--- a/tests/tools/labeled_data_builder/test_monte_carlo_cross_validation.py
+++ b/tests/tools/labeled_data_builder/test_monte_carlo_cross_validation.py
@@ -1,0 +1,121 @@
+"""Tests for methods in labeled_data_builder/monte_carlo_cross_validation.py."""
+
+from unittest import TestCase
+
+import pandas as pd
+
+from src.tools.labeled_data_builder.monte_carlo_cross_validation import generate_train_test_sample
+
+
+class TestLabeledDataBuilderMonteCarloCrossValidation(TestCase):
+    """Test class for methods in labeled_data_builder/monte_carlo_cross_validation.py."""
+
+    # Tests for method generate_train_test_sample()
+
+    def test_generate_train_test_sample_train_percentage_less_than_zero(self):
+
+        # Arrange
+        data = pd.DataFrame(
+            data={"features": [[0.1, -0.05], [-0.05, 0.02], [0.02, 0.12]], "label": [True, True, False]}
+        )
+        train_percentage = -0.1
+
+        # Act / Assert
+        with self.assertRaises(ValueError) as e:
+            generate_train_test_sample(data=data, train_percentage=train_percentage)
+        self.assertEqual("Parameter 'train_percentage' must be a number between 0 and 1 inclusive.", str(e.exception))
+
+    def test_generate_train_test_sample_train_percentage_greater_than_one(self):
+
+        # Arrange
+        data = pd.DataFrame(
+            data={"features": [[0.1, -0.05], [-0.05, 0.02], [0.02, 0.12]], "label": [True, True, False]}
+        )
+        train_percentage = 1.1
+
+        # Act / Assert
+        with self.assertRaises(ValueError) as e:
+            generate_train_test_sample(data=data, train_percentage=train_percentage)
+        self.assertEqual("Parameter 'train_percentage' must be a number between 0 and 1 inclusive.", str(e.exception))
+
+    def test_generate_train_test_sample_train_percentage_equals_zero(self):
+
+        # Arrange
+        data = pd.DataFrame(
+            data={"features": [[0.1, -0.05], [-0.05, 0.02], [0.02, 0.12]], "label": [True, True, False]}
+        )
+        train_percentage = 0
+
+        # Act
+        train_sample, test_sample = generate_train_test_sample(data=data, train_percentage=train_percentage)
+
+        # Assert
+        expected_test_sample = pd.DataFrame(
+            data={"features": [[0.1, -0.05], [-0.05, 0.02], [0.02, 0.12]], "label": [True, True, False]}
+        )
+        self.assertTrue(train_sample.empty)
+        self.assertEqual(set(expected_test_sample.index), set(test_sample.index))
+
+    def test_generate_train_test_sample_train_percentage_equals_one(self):
+
+        # Arrange
+        data = pd.DataFrame(
+            data={"features": [[0.1, -0.05], [-0.05, 0.02], [0.02, 0.12]], "label": [True, True, False]}
+        )
+        train_percentage = 1
+
+        # Act
+        train_sample, test_sample = generate_train_test_sample(data=data, train_percentage=train_percentage)
+
+        # Assert
+        expected_train_sample = pd.DataFrame(
+            data={"features": [[0.1, -0.05], [-0.05, 0.02], [0.02, 0.12]], "label": [True, True, False]}
+        )
+        self.assertEqual(set(expected_train_sample.index), set(train_sample.index))
+        self.assertTrue(test_sample.empty)
+
+    def test_generate_train_test_sample_data_is_empty(self):
+
+        # Arrange
+        data = pd.DataFrame()
+        train_percentage = 0.8
+
+        # Act
+        train_sample, test_sample = generate_train_test_sample(data=data, train_percentage=train_percentage)
+
+        # Assert
+        self.assertTrue(train_sample.empty)
+        self.assertTrue(pd.DataFrame().equals(train_sample))
+        self.assertTrue(test_sample.empty)
+        self.assertTrue(pd.DataFrame().equals(test_sample))
+
+    def test_generate_train_test_sample_sample_data_is_correct_length(self):
+
+        # Arrange
+        data = pd.DataFrame(
+            data={
+                "features": [
+                    [0.1, -0.05],
+                    [-0.05, 0.02],
+                    [0.02, 0.12],
+                    [0.12, -0.04],
+                    [-0.04, -0.1],
+                    [-0.1, 0.14],
+                    [0.14, -0.12],
+                    [-0.12, 0.2],
+                    [0.2, 0.01],
+                    [0.01, 0.13],
+                    [0.13, -0.09],
+                ],
+                "label": [True, True, False, False, True, False, True, True, True, False, False],
+            }
+        )
+        train_percentage = 0.8
+
+        # Act
+        train_sample, test_sample = generate_train_test_sample(data=data, train_percentage=train_percentage)
+
+        # Assert
+        self.assertEqual(9, len(train_sample))
+        self.assertEqual(2, len(test_sample))
+        self.assertEqual(11, len(set(list(train_sample.index) + list(test_sample.index))))


### PR DESCRIPTION
Use Monte-Carlo Cross-Validation to generate samples instead of bootstrapping, to avoid examples being in both the training and testing datasets

- Create method generate_train_test_sample() in new file labeled_data_builder/monte_carlo_cross_validation.py
- Add corresponding unit tests in new test file test_monte_carlo_cross_validation.py
- Edit method evaluate_and_compare() in classification_performance_evaluation_and_comparison.py to use monte_carlo_cross_validation.generate_train_test_sample() to generate validation samples, instead of bootstrap.generate_sample()