### PR TITLE
Add option to use all Close, High and Low in features

### DIFF
--- a/tests/tools/labeled_data_builder/test_time_series_forecasting.py
+++ b/tests/tools/labeled_data_builder/test_time_series_forecasting.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 
 import pandas as pd
 
+from src.tools.constants import PriceAttribute
 from src.tools.labeled_data_builder.time_series_forecasting import create_labeled_data
 
 
@@ -16,72 +17,166 @@ class TestLabeledDataBuilderTimeSeriesForecasting(TestCase):
     def test_create_labeled_data_ticker_label_empty_str(self):
 
         # Arrange
+        attribute_label = PriceAttribute.CLOSE
         ticker_label = ""
         tickers_features = ["CL=F", "EUR=X"]
         data = pd.DataFrame(
             data={
-                "Date": ["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"],
-                "CL=F": [True, False, False, True, True, False],
-                "EUR=X": [False, True, False, True, False, True],
+                ("CL=F", "Close"): [True, False, False, True, True, False],
+                ("EUR=X", "Close"): [False, True, False, True, False, True],
             }
-        ).set_index("Date")
-        data.index = pd.DatetimeIndex(data.index)
+        )
+        data.index = pd.DatetimeIndex(
+            pd.Series(
+                data=["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"], name="Date"
+            )
+        )
         features_length = 2
 
         # Act / Assert
         with self.assertRaises(ValueError) as e:
             create_labeled_data(
-                ticker_label=ticker_label, tickers_features=tickers_features, data=data, features_length=features_length
+                attribute_label=attribute_label,
+                ticker_label=ticker_label,
+                tickers_features=tickers_features,
+                data=data,
+                features_length=features_length,
             )
         self.assertEqual(
             str(e.exception),
-            "Parameter 'ticker_label' must represent a valid column in the 'data' provided as parameter.",
+            "Parameters 'ticker_label' and 'attribute_label' must represent a valid column in the 'data' provided as "
+            "parameter.",
         )
 
     def test_create_labeled_data_ticker_label_not_in_data_columns(self):
 
         # Arrange
+        attribute_label = PriceAttribute.CLOSE
         ticker_label = "GBPUSD=X"
         tickers_features = ["CL=F", "EUR=X"]
         data = pd.DataFrame(
             data={
-                "Date": ["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"],
-                "CL=F": [True, False, False, True, True, False],
-                "EUR=X": [False, True, False, True, False, True],
+                ("CL=F", "Close"): [True, False, False, True, True, False],
+                ("EUR=X", "Close"): [False, True, False, True, False, True],
             }
-        ).set_index("Date")
-        data.index = pd.DatetimeIndex(data.index)
+        )
+        data.index = pd.DatetimeIndex(
+            pd.Series(
+                data=["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"], name="Date"
+            )
+        )
         features_length = 2
 
         # Act / Assert
         with self.assertRaises(ValueError) as e:
             create_labeled_data(
-                ticker_label=ticker_label, tickers_features=tickers_features, data=data, features_length=features_length
+                attribute_label=attribute_label,
+                ticker_label=ticker_label,
+                tickers_features=tickers_features,
+                data=data,
+                features_length=features_length,
             )
         self.assertEqual(
             str(e.exception),
-            "Parameter 'ticker_label' must represent a valid column in the 'data' provided as parameter.",
+            "Parameters 'ticker_label' and 'attribute_label' must represent a valid column in the 'data' provided as "
+            "parameter.",
+        )
+
+    def test_create_labeled_data_attribute_label_not_in_data_columns(self):
+
+        # Arrange
+        attribute_label = PriceAttribute.HIGH
+        ticker_label = "EUR=X"
+        tickers_features = ["CL=F", "EUR=X"]
+        data = pd.DataFrame(
+            data={
+                ("CL=F", "Close"): [True, False, False, True, True, False],
+                ("EUR=X", "Close"): [False, True, False, True, False, True],
+            }
+        )
+        data.index = pd.DatetimeIndex(
+            pd.Series(
+                data=["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"], name="Date"
+            )
+        )
+        features_length = 2
+
+        # Act / Assert
+        with self.assertRaises(ValueError) as e:
+            create_labeled_data(
+                attribute_label=attribute_label,
+                ticker_label=ticker_label,
+                tickers_features=tickers_features,
+                data=data,
+                features_length=features_length,
+            )
+        self.assertEqual(
+            str(e.exception),
+            "Parameters 'ticker_label' and 'attribute_label' must represent a valid column in the 'data' provided as "
+            "parameter.",
+        )
+
+    def test_create_labeled_data_ticker_label_and_attribute_label_not_in_data_columns(self):
+
+        # Arrange
+        attribute_label = PriceAttribute.HIGH
+        ticker_label = "GBPUSD=X"
+        tickers_features = ["CL=F", "EUR=X"]
+        data = pd.DataFrame(
+            data={
+                ("CL=F", "Close"): [True, False, False, True, True, False],
+                ("EUR=X", "Close"): [False, True, False, True, False, True],
+            }
+        )
+        data.index = pd.DatetimeIndex(
+            pd.Series(
+                data=["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"], name="Date"
+            )
+        )
+        features_length = 2
+
+        # Act / Assert
+        with self.assertRaises(ValueError) as e:
+            create_labeled_data(
+                attribute_label=attribute_label,
+                ticker_label=ticker_label,
+                tickers_features=tickers_features,
+                data=data,
+                features_length=features_length,
+            )
+        self.assertEqual(
+            str(e.exception),
+            "Parameters 'ticker_label' and 'attribute_label' must represent a valid column in the 'data' provided as "
+            "parameter.",
         )
 
     def test_create_labeled_data_tickers_features_empty_list(self):
 
         # Arrange
+        attribute_label = PriceAttribute.CLOSE
         ticker_label = "EUR=X"
         tickers_features = []
         data = pd.DataFrame(
             data={
-                "Date": ["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"],
-                "CL=F": [True, False, False, True, True, False],
-                "EUR=X": [False, True, False, True, False, True],
+                ("CL=F", "Close"): [True, False, False, True, True, False],
+                ("EUR=X", "Close"): [False, True, False, True, False, True],
             }
-        ).set_index("Date")
-        data.index = pd.DatetimeIndex(data.index)
+        )
+        data.index = pd.DatetimeIndex(
+            pd.Series(
+                data=["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"], name="Date"
+            )
+        )
         features_length = 2
 
         # Act / Assert
         with self.assertRaises(ValueError) as e:
             create_labeled_data(
-                ticker_label=ticker_label, tickers_features=tickers_features, data=data, features_length=features_length
+                attribute_label=attribute_label,
+                ticker_label=ticker_label,
+                tickers_features=tickers_features,
+                data=data,
+                features_length=features_length,
             )
         self.assertEqual(
             str(e.exception),
@@ -91,22 +186,30 @@ class TestLabeledDataBuilderTimeSeriesForecasting(TestCase):
     def test_create_labeled_data_tickers_features_not_subset_of_data_columns(self):
 
         # Arrange
+        attribute_label = PriceAttribute.CLOSE
         ticker_label = "EUR=X"
         tickers_features = ["CL=F", "GC=F"]
         data = pd.DataFrame(
             data={
-                "Date": ["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"],
-                "CL=F": [True, False, False, True, True, False],
-                "EUR=X": [False, True, False, True, False, True],
+                ("CL=F", "Close"): [True, False, False, True, True, False],
+                ("EUR=X", "Close"): [False, True, False, True, False, True],
             }
-        ).set_index("Date")
-        data.index = pd.DatetimeIndex(data.index)
+        )
+        data.index = pd.DatetimeIndex(
+            pd.Series(
+                data=["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"], name="Date"
+            )
+        )
         features_length = 2
 
         # Act / Assert
         with self.assertRaises(ValueError) as e:
             create_labeled_data(
-                ticker_label=ticker_label, tickers_features=tickers_features, data=data, features_length=features_length
+                attribute_label=attribute_label,
+                ticker_label=ticker_label,
+                tickers_features=tickers_features,
+                data=data,
+                features_length=features_length,
             )
         self.assertEqual(
             str(e.exception),
@@ -116,65 +219,89 @@ class TestLabeledDataBuilderTimeSeriesForecasting(TestCase):
     def test_create_labeled_data_features_length_zero(self):
 
         # Arrange
+        attribute_label = PriceAttribute.CLOSE
         ticker_label = "EUR=X"
         tickers_features = ["CL=F", "EUR=X"]
         data = pd.DataFrame(
             data={
-                "Date": ["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"],
-                "CL=F": [True, False, False, True, True, False],
-                "EUR=X": [False, False, False, False, False, False],
+                ("CL=F", "Close"): [True, False, False, True, True, False],
+                ("EUR=X", "Close"): [False, False, False, False, False, False],
             }
-        ).set_index("Date")
-        data.index = pd.DatetimeIndex(data.index)
+        )
+        data.index = pd.DatetimeIndex(
+            pd.Series(
+                data=["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"], name="Date"
+            )
+        )
         features_length = 0
 
         # Act / Assert
         with self.assertRaises(ValueError) as e:
             create_labeled_data(
-                ticker_label=ticker_label, tickers_features=tickers_features, data=data, features_length=features_length
+                attribute_label=attribute_label,
+                ticker_label=ticker_label,
+                tickers_features=tickers_features,
+                data=data,
+                features_length=features_length,
             )
         self.assertEqual(str(e.exception), "Parameter 'features_length' must be a strictly positive integer (>= 1).")
 
     def test_create_labeled_data_features_length_negative(self):
 
         # Arrange
+        attribute_label = PriceAttribute.CLOSE
         ticker_label = "EUR=X"
         tickers_features = ["CL=F", "EUR=X"]
         data = pd.DataFrame(
             data={
-                "Date": ["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"],
-                "CL=F": [True, False, False, True, True, False],
-                "EUR=X": [False, True, False, True, False, True],
+                ("CL=F", "Close"): [True, False, False, True, True, False],
+                ("EUR=X", "Close"): [False, True, False, True, False, True],
             }
-        ).set_index("Date")
-        data.index = pd.DatetimeIndex(data.index)
+        )
+        data.index = pd.DatetimeIndex(
+            pd.Series(
+                data=["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"], name="Date"
+            )
+        )
         features_length = -1
 
         # Act / Assert
         with self.assertRaises(ValueError) as e:
             create_labeled_data(
-                ticker_label=ticker_label, tickers_features=tickers_features, data=data, features_length=features_length
+                attribute_label=attribute_label,
+                ticker_label=ticker_label,
+                tickers_features=tickers_features,
+                data=data,
+                features_length=features_length,
             )
         self.assertEqual(str(e.exception), "Parameter 'features_length' must be a strictly positive integer (>= 1).")
 
     def test_create_labeled_data_nan_in_features(self):
 
         # Arrange
+        attribute_label = PriceAttribute.CLOSE
         ticker_label = "EUR=X"
         tickers_features = ["CL=F", "EUR=X"]
         data = pd.DataFrame(
             data={
-                "Date": ["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"],
-                "CL=F": [0.1, math.nan, -0.05, 0.05, 0.2, -0.1],
-                "EUR=X": [-0.1, 0.08, -0.04, 0.22, -0.12, 0.05],
+                ("CL=F", "Close"): [0.1, math.nan, -0.05, 0.05, 0.2, -0.1],
+                ("EUR=X", "Close"): [-0.1, 0.08, -0.04, 0.22, -0.12, 0.05],
             }
-        ).set_index("Date")
-        data.index = pd.DatetimeIndex(data.index)
+        )
+        data.index = pd.DatetimeIndex(
+            pd.Series(
+                data=["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"], name="Date"
+            )
+        )
         features_length = 2
 
         # Act
         labeled_data = create_labeled_data(
-            ticker_label=ticker_label, tickers_features=tickers_features, data=data, features_length=features_length
+            attribute_label=attribute_label,
+            ticker_label=ticker_label,
+            tickers_features=tickers_features,
+            data=data,
+            features_length=features_length,
         )
 
         # Assert
@@ -193,21 +320,29 @@ class TestLabeledDataBuilderTimeSeriesForecasting(TestCase):
     def test_create_labeled_data_nan_in_label(self):
 
         # Arrange
+        attribute_label = PriceAttribute.CLOSE
         ticker_label = "EUR=X"
         tickers_features = ["CL=F"]
         data = pd.DataFrame(
             data={
-                "Date": ["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"],
-                "CL=F": [0.1, -0.06, -0.05, 0.05, 0.2, -0.1],
-                "EUR=X": [-0.1, 0.08, -0.04, math.nan, -0.12, 0.05],
+                ("CL=F", "Close"): [0.1, -0.06, -0.05, 0.05, 0.2, -0.1],
+                ("EUR=X", "Close"): [-0.1, 0.08, -0.04, math.nan, -0.12, 0.05],
             }
-        ).set_index("Date")
-        data.index = pd.DatetimeIndex(data.index)
+        )
+        data.index = pd.DatetimeIndex(
+            pd.Series(
+                data=["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"], name="Date"
+            )
+        )
         features_length = 2
 
         # Act
         labeled_data = create_labeled_data(
-            ticker_label=ticker_label, tickers_features=tickers_features, data=data, features_length=features_length
+            attribute_label=attribute_label,
+            ticker_label=ticker_label,
+            tickers_features=tickers_features,
+            data=data,
+            features_length=features_length,
         )
 
         # Assert
@@ -226,21 +361,25 @@ class TestLabeledDataBuilderTimeSeriesForecasting(TestCase):
     def test_create_labeled_data_data_empty(self):
 
         # Arrange
+        attribute_label = PriceAttribute.CLOSE
         ticker_label = "EUR=X"
         tickers_features = ["CL=F", "EUR=X"]
         data = pd.DataFrame(
             data={
-                "Date": [],
-                "CL=F": [],
-                "EUR=X": [],
+                ("CL=F", "Close"): [],
+                ("EUR=X", "Close"): [],
             }
-        ).set_index("Date")
-        data.index = pd.DatetimeIndex(data.index)
+        )
+        data.index = pd.DatetimeIndex(pd.Series(data=[], name="Date", dtype="str"))
         features_length = 2
 
         # Act
         labeled_data = create_labeled_data(
-            ticker_label=ticker_label, tickers_features=tickers_features, data=data, features_length=features_length
+            attribute_label=attribute_label,
+            ticker_label=ticker_label,
+            tickers_features=tickers_features,
+            data=data,
+            features_length=features_length,
         )
 
         # Assert
@@ -259,21 +398,29 @@ class TestLabeledDataBuilderTimeSeriesForecasting(TestCase):
     def test_create_labeled_data_data_nan_only(self):
 
         # Arrange
+        attribute_label = PriceAttribute.CLOSE
         ticker_label = "EUR=X"
         tickers_features = ["CL=F"]
         data = pd.DataFrame(
             data={
-                "Date": ["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"],
-                "CL=F": [math.nan, math.nan, math.nan, math.nan, math.nan, math.nan],
-                "EUR=X": [math.nan, math.nan, math.nan, math.nan, math.nan, math.nan],
+                ("CL=F", "Close"): [math.nan, math.nan, math.nan, math.nan, math.nan, math.nan],
+                ("EUR=X", "Close"): [math.nan, math.nan, math.nan, math.nan, math.nan, math.nan],
             }
-        ).set_index("Date")
-        data.index = pd.DatetimeIndex(data.index)
+        )
+        data.index = pd.DatetimeIndex(
+            pd.Series(
+                data=["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"], name="Date"
+            )
+        )
         features_length = 2
 
         # Act
         labeled_data = create_labeled_data(
-            ticker_label=ticker_label, tickers_features=tickers_features, data=data, features_length=features_length
+            attribute_label=attribute_label,
+            ticker_label=ticker_label,
+            tickers_features=tickers_features,
+            data=data,
+            features_length=features_length,
         )
 
         # Assert
@@ -292,21 +439,29 @@ class TestLabeledDataBuilderTimeSeriesForecasting(TestCase):
     def test_create_labeled_data_one_example(self):
 
         # Arrange
+        attribute_label = PriceAttribute.CLOSE
         ticker_label = "EUR=X"
         tickers_features = ["CL=F", "EUR=X"]
         data = pd.DataFrame(
             data={
-                "Date": ["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"],
-                "CL=F": [0.1, -0.06, -0.05, 0.05, 0.2, -0.1],
-                "EUR=X": [-0.1, 0.08, -0.04, 0.22, -0.12, 0.05],
+                ("CL=F", "Close"): [0.1, -0.06, -0.05, 0.05, 0.2, -0.1],
+                ("EUR=X", "Close"): [-0.1, 0.08, -0.04, 0.22, -0.12, 0.05],
             }
-        ).set_index("Date")
-        data.index = pd.DatetimeIndex(data.index)
+        )
+        data.index = pd.DatetimeIndex(
+            pd.Series(
+                data=["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"], name="Date"
+            )
+        )
         features_length = 5
 
         # Act
         labeled_data = create_labeled_data(
-            ticker_label=ticker_label, tickers_features=tickers_features, data=data, features_length=features_length
+            attribute_label=attribute_label,
+            ticker_label=ticker_label,
+            tickers_features=tickers_features,
+            data=data,
+            features_length=features_length,
         )
 
         # Assert
@@ -327,21 +482,29 @@ class TestLabeledDataBuilderTimeSeriesForecasting(TestCase):
     def test_create_labeled_data_zero_example(self):
 
         # Arrange
+        attribute_label = PriceAttribute.CLOSE
         ticker_label = "EUR=X"
         tickers_features = ["CL=F", "EUR=X"]
         data = pd.DataFrame(
             data={
-                "Date": ["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"],
-                "CL=F": [0.1, -0.06, -0.05, 0.05, 0.2, -0.1],
-                "EUR=X": [-0.1, 0.08, -0.04, 0.22, -0.12, 0.05],
+                ("CL=F", "Close"): [0.1, -0.06, -0.05, 0.05, 0.2, -0.1],
+                ("EUR=X", "Close"): [-0.1, 0.08, -0.04, 0.22, -0.12, 0.05],
             }
-        ).set_index("Date")
-        data.index = pd.DatetimeIndex(data.index)
+        )
+        data.index = pd.DatetimeIndex(
+            pd.Series(
+                data=["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"], name="Date"
+            )
+        )
         features_length = 6
 
         # Act
         labeled_data = create_labeled_data(
-            ticker_label=ticker_label, tickers_features=tickers_features, data=data, features_length=features_length
+            attribute_label=attribute_label,
+            ticker_label=ticker_label,
+            tickers_features=tickers_features,
+            data=data,
+            features_length=features_length,
         )
 
         # Assert
@@ -360,21 +523,29 @@ class TestLabeledDataBuilderTimeSeriesForecasting(TestCase):
     def test_create_labeled_data_ticker_label_in_tickers_features(self):
 
         # Arrange
+        attribute_label = PriceAttribute.CLOSE
         ticker_label = "EUR=X"
         tickers_features = ["CL=F", "EUR=X"]
         data = pd.DataFrame(
             data={
-                "Date": ["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"],
-                "CL=F": [0.1, -0.06, -0.05, 0.05, 0.2, -0.1],
-                "EUR=X": [-0.1, 0.08, -0.04, 0.22, -0.12, 0.05],
+                ("CL=F", "Close"): [0.1, -0.06, -0.05, 0.05, 0.2, -0.1],
+                ("EUR=X", "Close"): [-0.1, 0.08, -0.04, 0.22, -0.12, 0.05],
             }
-        ).set_index("Date")
-        data.index = pd.DatetimeIndex(data.index)
+        )
+        data.index = pd.DatetimeIndex(
+            pd.Series(
+                data=["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"], name="Date"
+            )
+        )
         features_length = 3
 
         # Act
         labeled_data = create_labeled_data(
-            ticker_label=ticker_label, tickers_features=tickers_features, data=data, features_length=features_length
+            attribute_label=attribute_label,
+            ticker_label=ticker_label,
+            tickers_features=tickers_features,
+            data=data,
+            features_length=features_length,
         )
 
         # Assert
@@ -409,21 +580,29 @@ class TestLabeledDataBuilderTimeSeriesForecasting(TestCase):
     def test_create_labeled_data_ticker_label_not_in_tickers_features(self):
 
         # Arrange
+        attribute_label = PriceAttribute.CLOSE
         ticker_label = "EUR=X"
         tickers_features = ["CL=F"]
         data = pd.DataFrame(
             data={
-                "Date": ["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"],
-                "CL=F": [0.1, -0.06, -0.05, 0.05, 0.2, -0.1],
-                "EUR=X": [-0.1, 0.08, -0.04, 0.22, -0.12, 0.05],
+                ("CL=F", "Close"): [0.1, -0.06, -0.05, 0.05, 0.2, -0.1],
+                ("EUR=X", "Close"): [-0.1, 0.08, -0.04, 0.22, -0.12, 0.05],
             }
-        ).set_index("Date")
-        data.index = pd.DatetimeIndex(data.index)
+        )
+        data.index = pd.DatetimeIndex(
+            pd.Series(
+                data=["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"], name="Date"
+            )
+        )
         features_length = 3
 
         # Act
         labeled_data = create_labeled_data(
-            ticker_label=ticker_label, tickers_features=tickers_features, data=data, features_length=features_length
+            attribute_label=attribute_label,
+            ticker_label=ticker_label,
+            tickers_features=tickers_features,
+            data=data,
+            features_length=features_length,
         )
 
         # Assert
@@ -447,6 +626,65 @@ class TestLabeledDataBuilderTimeSeriesForecasting(TestCase):
                 "features_sector": [
                     [-0.06, 0.08, -0.05, -0.04, 0.05, 0.22],
                     [-0.05, -0.04, 0.05, 0.22, 0.2, -0.12],
+                ],
+                "label_classification": [False, True],
+                "label_regression": [-0.12, 0.05],
+            }
+        ).set_index("timestamp")
+        expected_labeled_data_2.index = pd.DatetimeIndex(expected_labeled_data_2.index)
+        self.assertTrue(expected_labeled_data_1.equals(labeled_data) or expected_labeled_data_2.equals(labeled_data))
+
+    def test_create_labeled_data_multiple_price_attributes_in_data(self):
+
+        # Arrange
+        attribute_label = PriceAttribute.CLOSE
+        ticker_label = "EUR=X"
+        tickers_features = ["CL=F", "EUR=X"]
+        data = pd.DataFrame(
+            data={
+                ("CL=F", "Close"): [0.1, -0.06, -0.05, 0.05, 0.2, -0.1],
+                ("CL=F", "High"): [0.2, 0.12, 0.1, 0.1, 0.4, 0.2],
+                ("EUR=X", "Close"): [-0.1, 0.08, -0.04, 0.22, -0.12, 0.05],
+                ("EUR=X", "High"): [0.2, 0.16, 0.08, 0.44, 0.24, 0.1],
+            }
+        )
+        data.index = pd.DatetimeIndex(
+            pd.Series(
+                data=["2022-11-07", "2022-11-08", "2022-11-09", "2022-11-10", "2022-11-11", "2022-11-14"], name="Date"
+            )
+        )
+        features_length = 3
+
+        # Act
+        labeled_data = create_labeled_data(
+            attribute_label=attribute_label,
+            ticker_label=ticker_label,
+            tickers_features=tickers_features,
+            data=data,
+            features_length=features_length,
+        )
+
+        # Assert
+        expected_labeled_data_1 = pd.DataFrame(
+            data={
+                "timestamp": ["2022-11-10", "2022-11-11"],
+                "features_individual": [[-0.1, 0.2, 0.08, 0.16, -0.04, 0.08], [0.08, 0.16, -0.04, 0.08, 0.22, 0.44]],
+                "features_sector": [
+                    [0.1, 0.2, -0.1, 0.2, -0.06, 0.12, 0.08, 0.16, -0.05, 0.1, -0.04, 0.08],
+                    [-0.06, 0.12, 0.08, 0.16, -0.05, 0.1, -0.04, 0.08, 0.05, 0.1, 0.22, 0.44],
+                ],
+                "label_classification": [True, False],
+                "label_regression": [0.22, -0.12],
+            }
+        ).set_index("timestamp")
+        expected_labeled_data_1.index = pd.DatetimeIndex(expected_labeled_data_1.index)
+        expected_labeled_data_2 = pd.DataFrame(
+            data={
+                "timestamp": ["2022-11-11", "2022-11-14"],
+                "features_individual": [[0.08, 0.16, -0.04, 0.08, 0.22, 0.44], [-0.04, 0.08, 0.22, 0.44, -0.12, 0.24]],
+                "features_sector": [
+                    [-0.06, 0.12, 0.08, 0.16, -0.05, 0.1, -0.04, 0.08, 0.05, 0.1, 0.22, 0.44],
+                    [-0.05, 0.1, -0.04, 0.08, 0.05, 0.1, 0.22, 0.44, 0.2, 0.4, -0.12, 0.24],
                 ],
                 "label_classification": [False, True],
                 "label_regression": [-0.12, 0.05],

--- a/tests/tools/test_yfinance_data_provider.py
+++ b/tests/tools/test_yfinance_data_provider.py
@@ -291,53 +291,16 @@ class TestYfinanceDataProvider(TestCase):
     # Tests for method get_hourly_changes()
 
     @patch("src.tools.yfinance_data_provider.YfinanceDataProvider.get_data")
-    def test_get_hourly_changes_single_ticker_str(self, mock_get_data_method):
+    def test_get_hourly_changes_single_ticker_and_single_attribute(self, mock_get_data_method):
 
         # Arrange
         mock_get_data_method.side_effect = self.mock_download_side_effect
-        attribute = PriceAttribute.CLOSE
-        tickers = "CL=F"
-        period = "7h"
-
-        # Act
-        changes_data = YfinanceDataProvider.get_hourly_changes(attribute=attribute, tickers=tickers, period=period)
-
-        # Assert
-        expected_parameters = {
-            "tickers": "CL=F",
-            "period": "7h",
-            "interval": YfinanceInterval.ONE_HOUR,
-            "group_by": YfinanceGroupBy.TICKER,
-        }
-        self.assertEqual(expected_parameters, self.parameters)
-        expected_changes_series = pd.Series(
-            data={
-                "2023-02-01 02:00:00-05:00": 0.0006307774541483123,
-                "2023-02-01 03:00:00-05:00": 0.003026454659943564,
-                "2023-02-01 04:00:00-05:00": -0.007793874579472201,
-                "2023-02-01 05:00:00-05:00": -0.00025341109503747235,
-                "2023-02-01 06:00:00-05:00": 0.006208005344925863,
-                "2023-02-01 07:00:00-05:00": -0.002896402799731141,
-                "2023-02-01 08:00:00-05:00": 0.0013892474100479647,
-            }
-        )
-        expected_changes_series.index = pd.DatetimeIndex(
-            expected_changes_series.index, dtype="datetime64[ns, America/New_York]"
-        )
-        expected_changes_data = pd.DataFrame(data={"CL=F": expected_changes_series})
-        self.assertTrue(expected_changes_data.equals(changes_data))
-
-    @patch("src.tools.yfinance_data_provider.YfinanceDataProvider.get_data")
-    def test_get_hourly_changes_single_ticker_list(self, mock_get_data_method):
-
-        # Arrange
-        mock_get_data_method.side_effect = self.mock_download_side_effect
-        attribute = PriceAttribute.CLOSE
+        attributes = [PriceAttribute.CLOSE]
         tickers = ["CL=F"]
         period = "7h"
 
         # Act
-        changes_data = YfinanceDataProvider.get_hourly_changes(attribute=attribute, tickers=tickers, period=period)
+        changes_data = YfinanceDataProvider.get_hourly_changes(attributes=attributes, tickers=tickers, period=period)
 
         # Assert
         expected_parameters = {
@@ -361,20 +324,20 @@ class TestYfinanceDataProvider(TestCase):
         expected_changes_series.index = pd.DatetimeIndex(
             expected_changes_series.index, dtype="datetime64[ns, America/New_York]"
         )
-        expected_changes_data = pd.DataFrame(data={"CL=F": expected_changes_series})
+        expected_changes_data = pd.DataFrame(data={("CL=F", "Close"): expected_changes_series})
         self.assertTrue(expected_changes_data.equals(changes_data))
 
     @patch("src.tools.yfinance_data_provider.YfinanceDataProvider.get_data")
-    def test_get_hourly_changes_multiple_tickers_list(self, mock_get_data_method):
+    def test_get_hourly_changes_multiple_tickers_and_single_attribute(self, mock_get_data_method):
 
         # Arrange
         mock_get_data_method.side_effect = self.mock_download_side_effect
-        attribute = PriceAttribute.CLOSE
+        attributes = [PriceAttribute.CLOSE]
         tickers = ["CL=F", "EUR=X"]
         period = "7h"
 
         # Act
-        changes_data = YfinanceDataProvider.get_hourly_changes(attribute=attribute, tickers=tickers, period=period)
+        changes_data = YfinanceDataProvider.get_hourly_changes(attributes=attributes, tickers=tickers, period=period)
 
         # Assert
         expected_parameters = {
@@ -410,38 +373,155 @@ class TestYfinanceDataProvider(TestCase):
         expected_changes_series_eur.index = pd.DatetimeIndex(expected_changes_series_eur.index)
         expected_changes_data = pd.DataFrame(
             data={
-                "CL=F": expected_changes_series_cl,
-                "EUR=X": expected_changes_series_eur,
+                ("CL=F", "Close"): expected_changes_series_cl,
+                ("EUR=X", "Close"): expected_changes_series_eur,
             }
         )
         self.assertTrue(expected_changes_data.equals(changes_data))
 
-    @patch("yfinance.download")
-    def test_get_hourly_changes_tickers_empty_str(self, mock_download_method):
+    @patch("src.tools.yfinance_data_provider.YfinanceDataProvider.get_data")
+    def test_get_hourly_changes_single_ticker_and_multiple_attributes(self, mock_get_data_method):
 
         # Arrange
-        mock_download_method.side_effect = self.mock_download_side_effect
-        attribute = PriceAttribute.CLOSE
-        tickers = ""
+        mock_get_data_method.side_effect = self.mock_download_side_effect
+        attributes = [PriceAttribute.CLOSE, PriceAttribute.HIGH]
+        tickers = ["CL=F"]
         period = "7h"
 
-        # Act / Assert
-        with self.assertRaises(ValueError) as e:
-            YfinanceDataProvider.get_hourly_changes(attribute=attribute, tickers=tickers, period=period)
-        self.assertEqual(str(e.exception), "Parameter 'tickers' cannot be empty.")
+        # Act
+        changes_data = YfinanceDataProvider.get_hourly_changes(attributes=attributes, tickers=tickers, period=period)
+
+        # Assert
+        expected_parameters = {
+            "tickers": ["CL=F"],
+            "period": "7h",
+            "interval": YfinanceInterval.ONE_HOUR,
+            "group_by": YfinanceGroupBy.TICKER,
+        }
+        self.assertEqual(expected_parameters, self.parameters)
+        expected_changes_series_close = pd.Series(
+            data={
+                "2023-02-01 02:00:00-05:00": 0.0006307774541483123,
+                "2023-02-01 03:00:00-05:00": 0.003026454659943564,
+                "2023-02-01 04:00:00-05:00": -0.007793874579472201,
+                "2023-02-01 05:00:00-05:00": -0.00025341109503747235,
+                "2023-02-01 06:00:00-05:00": 0.006208005344925863,
+                "2023-02-01 07:00:00-05:00": -0.002896402799731141,
+                "2023-02-01 08:00:00-05:00": 0.0013892474100479647,
+            }
+        )
+        expected_changes_series_close.index = pd.DatetimeIndex(
+            expected_changes_series_close.index, dtype="datetime64[ns, America/New_York]"
+        )
+        expected_changes_series_high = pd.Series(
+            data={
+                "2023-02-01 02:00:00-05:00": 0.0022710106021243907,
+                "2023-02-01 03:00:00-05:00": 0.005422450045747503,
+                "2023-02-01 04:00:00-05:00": 0.00025137199621973346,
+                "2023-02-01 05:00:00-05:00": 0.0027869421573228654,
+                "2023-02-01 06:00:00-05:00": 0.006461448552623731,
+                "2023-02-01 07:00:00-05:00": 0.003903759530257595,
+                "2023-02-01 08:00:00-05:00": 0.0036625525942109295,
+            }
+        )
+        expected_changes_series_high.index = pd.DatetimeIndex(
+            expected_changes_series_high.index, dtype="datetime64[ns, America/New_York]"
+        )
+        expected_changes_data = pd.DataFrame(
+            data={("CL=F", "Close"): expected_changes_series_close, ("CL=F", "High"): expected_changes_series_high}
+        )
+        self.assertTrue(expected_changes_data.equals(changes_data))
+
+    @patch("src.tools.yfinance_data_provider.YfinanceDataProvider.get_data")
+    def test_get_hourly_changes_multiple_tickers_and_multiple_attributes(self, mock_get_data_method):
+
+        # Arrange
+        mock_get_data_method.side_effect = self.mock_download_side_effect
+        attributes = [PriceAttribute.CLOSE, PriceAttribute.LOW]
+        tickers = ["CL=F", "EUR=X"]
+        period = "7h"
+
+        # Act
+        changes_data = YfinanceDataProvider.get_hourly_changes(attributes=attributes, tickers=tickers, period=period)
+
+        # Assert
+        expected_parameters = {
+            "tickers": ["CL=F", "EUR=X"],
+            "period": "7h",
+            "interval": YfinanceInterval.ONE_HOUR,
+            "group_by": YfinanceGroupBy.TICKER,
+        }
+        self.assertEqual(expected_parameters, self.parameters)
+        expected_changes_series_cl_close = pd.Series(
+            data={
+                "2023-02-01 07:00:00+00:00": 0.0030352581850995137,
+                "2023-02-01 08:00:00+00:00": 0.003026454659943564,
+                "2023-02-01 09:00:00+00:00": -0.007793874579472201,
+                "2023-02-01 10:00:00+00:00": -0.00025341109503747235,
+                "2023-02-01 11:00:00+00:00": 0.006208005344925863,
+                "2023-02-01 12:00:00+00:00": -0.002896402799731141,
+                "2023-02-01 13:00:00+00:00": 0.0010103792718659285,
+            }
+        )
+        expected_changes_series_cl_close.index = pd.DatetimeIndex(expected_changes_series_cl_close.index)
+        expected_changes_series_cl_low = pd.Series(
+            data={
+                "2023-02-01 02:00:00-05:00": 0.0,
+                "2023-02-01 03:00:00-05:00": -0.0015132754346012752,
+                "2023-02-01 04:00:00-05:00": -0.009050926374379506,
+                "2023-02-01 05:00:00-05:00": -0.0022802166152628093,
+                "2023-02-01 06:00:00-05:00": -0.0015203692654003722,
+                "2023-02-01 07:00:00-05:00": -0.00352608482279937,
+                "2023-02-01 08:00:00-05:00": -0.0013892474100479647,
+            }
+        )
+        expected_changes_series_cl_low.index = pd.DatetimeIndex(expected_changes_series_cl_low.index)
+        expected_changes_series_eur_close = pd.Series(
+            data={
+                "2023-02-01 07:00:00+00:00": -0.0010873618584464582,
+                "2023-02-01 08:00:00+00:00": -0.0005442078713167677,
+                "2023-02-01 09:00:00+00:00": 0.00043564230462633823,
+                "2023-02-01 10:00:00+00:00": -0.0008709052061015792,
+                "2023-02-01 11:00:00+00:00": -0.0003267866914642771,
+                "2023-02-01 12:00:00+00:00": 0.00021797231063184626,
+                "2023-02-01 13:00:00+00:00": -0.001307354046709806,
+            }
+        )
+        expected_changes_series_eur_close.index = pd.DatetimeIndex(expected_changes_series_eur_close.index)
+        expected_changes_series_eur_low = pd.Series(
+            data={
+                "2023-02-01 07:00:00+00:00": -0.0010873618584464582,
+                "2023-02-01 08:00:00+00:00": -0.0007619429233123652,
+                "2023-02-01 09:00:00+00:00": 0.0,
+                "2023-02-01 10:00:00+00:00": -0.0009797845784632578,
+                "2023-02-01 11:00:00+00:00": -0.0007625239230193662,
+                "2023-02-01 12:00:00+00:00": -0.0004358796712307271,
+                "2023-02-01 13:00:00+00:00": -0.001525278855767478,
+            }
+        )
+        expected_changes_series_eur_low.index = pd.DatetimeIndex(expected_changes_series_eur_low.index)
+        expected_changes_data = pd.DataFrame(
+            data={
+                ("CL=F", "Close"): expected_changes_series_cl_close,
+                ("CL=F", "Low"): expected_changes_series_cl_low,
+                ("EUR=X", "Close"): expected_changes_series_eur_close,
+                ("EUR=X", "Low"): expected_changes_series_eur_low,
+            }
+        )
+        self.assertTrue(expected_changes_data.equals(changes_data))
 
     @patch("yfinance.download")
     def test_get_hourly_changes_tickers_empty_list(self, mock_download_method):
 
         # Arrange
         mock_download_method.side_effect = self.mock_download_side_effect
-        attribute = PriceAttribute.CLOSE
+        attributes = [PriceAttribute.CLOSE]
         tickers = []
         period = "7h"
 
         # Act / Assert
         with self.assertRaises(ValueError) as e:
-            YfinanceDataProvider.get_hourly_changes(attribute=attribute, tickers=tickers, period=period)
+            YfinanceDataProvider.get_hourly_changes(attributes=attributes, tickers=tickers, period=period)
         self.assertEqual(str(e.exception), "Parameter 'tickers' cannot be empty.")
 
     @patch("src.tools.yfinance_data_provider.YfinanceDataProvider.get_data")
@@ -449,12 +529,12 @@ class TestYfinanceDataProvider(TestCase):
 
         # Arrange
         mock_get_data_method.side_effect = self.mock_download_side_effect
-        attribute = PriceAttribute.CLOSE
+        attributes = [PriceAttribute.CLOSE]
         tickers = ["CL=F", "EUR=X"]
         period = YfinancePeriod.ONE_DAY
 
         # Act
-        changes_data = YfinanceDataProvider.get_hourly_changes(attribute=attribute, tickers=tickers, period=period)
+        changes_data = YfinanceDataProvider.get_hourly_changes(attributes=attributes, tickers=tickers, period=period)
 
         # Assert
         expected_parameters = {
@@ -490,8 +570,8 @@ class TestYfinanceDataProvider(TestCase):
         expected_changes_series_eur.index = pd.DatetimeIndex(expected_changes_series_eur.index)
         expected_changes_data = pd.DataFrame(
             data={
-                "CL=F": expected_changes_series_cl,
-                "EUR=X": expected_changes_series_eur,
+                ("CL=F", "Close"): expected_changes_series_cl,
+                ("EUR=X", "Close"): expected_changes_series_eur,
             }
         )
         self.assertTrue(expected_changes_data.equals(changes_data))
@@ -501,11 +581,11 @@ class TestYfinanceDataProvider(TestCase):
 
         # Arrange
         mock_get_data_method.side_effect = self.mock_download_side_effect
-        attribute = PriceAttribute.CLOSE
+        attributes = [PriceAttribute.CLOSE]
         tickers = ["CL=F", "EUR=X"]
 
         # Act
-        changes_data = YfinanceDataProvider.get_hourly_changes(attribute=attribute, tickers=tickers)
+        changes_data = YfinanceDataProvider.get_hourly_changes(attributes=attributes, tickers=tickers)
 
         # Assert
         expected_parameters = {
@@ -541,34 +621,86 @@ class TestYfinanceDataProvider(TestCase):
         expected_changes_series_eur.index = pd.DatetimeIndex(expected_changes_series_eur.index)
         expected_changes_data = pd.DataFrame(
             data={
-                "CL=F": expected_changes_series_cl,
-                "EUR=X": expected_changes_series_eur,
+                ("CL=F", "Close"): expected_changes_series_cl,
+                ("EUR=X", "Close"): expected_changes_series_eur,
             }
         )
         self.assertTrue(expected_changes_data.equals(changes_data))
 
     @patch("src.tools.yfinance_data_provider.YfinanceDataProvider.get_data")
-    def test_get_hourly_changes_attribute_is_open(self, mock_get_data_method):
+    def test_get_hourly_changes_attributes_is_empty_list(self, mock_get_data_method):
 
         # Arrange
         mock_get_data_method.side_effect = self.mock_download_side_effect
-        attribute = PriceAttribute.OPEN
+        attributes = []
+        tickers = ["CL=F", "EUR=X"]
+
+        # Act / Assert
+        with self.assertRaises(ValueError) as e:
+            YfinanceDataProvider.get_hourly_changes(attributes=attributes, tickers=tickers)
+        self.assertEqual("Parameter 'attributes' cannot be empty.", str(e.exception))
+
+    @patch("src.tools.yfinance_data_provider.YfinanceDataProvider.get_data")
+    def test_get_hourly_changes_attributes_is_open(self, mock_get_data_method):
+
+        # Arrange
+        mock_get_data_method.side_effect = self.mock_download_side_effect
+        attributes = [PriceAttribute.OPEN]
         tickers = ["CL=F", "EUR=X"]
 
         # Act
         with self.assertRaises(ValueError) as e:
-            YfinanceDataProvider.get_hourly_changes(attribute=attribute, tickers=tickers)
+            YfinanceDataProvider.get_hourly_changes(attributes=attributes, tickers=tickers)
         self.assertEqual("Cannot extract changes for price attributes 'Open' or 'Volume'.", str(e.exception))
 
     @patch("src.tools.yfinance_data_provider.YfinanceDataProvider.get_data")
-    def test_get_hourly_changes_attribute_is_volume(self, mock_get_data_method):
+    def test_get_hourly_changes_attributes_is_volume(self, mock_get_data_method):
 
         # Arrange
         mock_get_data_method.side_effect = self.mock_download_side_effect
-        attribute = PriceAttribute.VOLUME
+        attributes = [PriceAttribute.VOLUME]
         tickers = ["CL=F", "EUR=X"]
 
         # Act
         with self.assertRaises(ValueError) as e:
-            YfinanceDataProvider.get_hourly_changes(attribute=attribute, tickers=tickers)
+            YfinanceDataProvider.get_hourly_changes(attributes=attributes, tickers=tickers)
+        self.assertEqual("Cannot extract changes for price attributes 'Open' or 'Volume'.", str(e.exception))
+
+    @patch("src.tools.yfinance_data_provider.YfinanceDataProvider.get_data")
+    def test_get_hourly_changes_attributes_contains_open(self, mock_get_data_method):
+
+        # Arrange
+        mock_get_data_method.side_effect = self.mock_download_side_effect
+        attributes = [PriceAttribute.CLOSE, PriceAttribute.OPEN]
+        tickers = ["CL=F", "EUR=X"]
+
+        # Act
+        with self.assertRaises(ValueError) as e:
+            YfinanceDataProvider.get_hourly_changes(attributes=attributes, tickers=tickers)
+        self.assertEqual("Cannot extract changes for price attributes 'Open' or 'Volume'.", str(e.exception))
+
+    @patch("src.tools.yfinance_data_provider.YfinanceDataProvider.get_data")
+    def test_get_hourly_changes_attributes_contains_volume(self, mock_get_data_method):
+
+        # Arrange
+        mock_get_data_method.side_effect = self.mock_download_side_effect
+        attributes = [PriceAttribute.CLOSE, PriceAttribute.VOLUME]
+        tickers = ["CL=F", "EUR=X"]
+
+        # Act
+        with self.assertRaises(ValueError) as e:
+            YfinanceDataProvider.get_hourly_changes(attributes=attributes, tickers=tickers)
+        self.assertEqual("Cannot extract changes for price attributes 'Open' or 'Volume'.", str(e.exception))
+
+    @patch("src.tools.yfinance_data_provider.YfinanceDataProvider.get_data")
+    def test_get_hourly_changes_attributes_contains_open_and_volume(self, mock_get_data_method):
+
+        # Arrange
+        mock_get_data_method.side_effect = self.mock_download_side_effect
+        attributes = [PriceAttribute.CLOSE, PriceAttribute.OPEN, PriceAttribute.VOLUME]
+        tickers = ["CL=F", "EUR=X"]
+
+        # Act
+        with self.assertRaises(ValueError) as e:
+            YfinanceDataProvider.get_hourly_changes(attributes=attributes, tickers=tickers)
         self.assertEqual("Cannot extract changes for price attributes 'Open' or 'Volume'.", str(e.exception))


### PR DESCRIPTION
- Edit method get_hourly_changes() in yfinance_data_provider.py to add 'attributes' list parameter and change 'tickers' type hint to List[str] only
- Adapt and add tests in test_yfinance_data_provider.py accordingly
- Edit method create_labeled_data() in labeled_data_builder/time_series_forecasting.py to add 'attribute_label' parameter to decide which price attribute to use as label if the provided data contains multiple price attributes
- Adapt and add tests in test_time_series_forecasting.py accordingly
- Edit methods evaluate_and_compare_classification() and evaluate_and_compare_regression() to add a 'use_close_high_low' boolean parameter to decide whether to use the target price attribute only as feature or all Close/High/Low